### PR TITLE
Add support for local testing and update deprecated calls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,24 @@
+FROM php:7.4-cli
+
+RUN apt-get update
+RUN apt-get install -y wget
+
+# Install Golang
+RUN wget https://dl.google.com/go/go1.13.3.linux-amd64.tar.gz
+RUN tar -xvf go1.13.3.linux-amd64.tar.gz -C /usr/local
+ENV PATH=/usr/local/go/bin:$PATH
+ENV GOROOT=/usr/local/go
+
+# Build php-go
+COPY . /gopath/src/github.com/arnaud-lb/php-go
+ENV GOPATH=/gopath
+WORKDIR /gopath/src/github.com/arnaud-lb/php-go/ext/tests/fixtures/go
+RUN go build -o test.so -buildmode c-shared
+
+# Install the extension
+WORKDIR /gopath/src/github.com/arnaud-lb/php-go/ext
+RUN phpize && ./configure && make && make install
+RUN echo "extension = phpgo.so" >> /gopath/src/github.com/arnaud-lb/php-go/ext/tmp-php.ini
+
+# Execute the test
+CMD cd /gopath/src/github.com/arnaud-lb/php-go/ext && ../local-test.sh

--- a/README.md
+++ b/README.md
@@ -86,3 +86,19 @@ ReflectionClass::export($module);
 // Call some method
 $module->toUpper("foo");
 ```
+
+## Development
+
+#### Run tests locally
+
+To run the PHP test suites locally, either use the all-in-one command:
+
+```shell script
+docker run --rm -it $(docker build -q .)
+```
+
+Or alternatively, to view build output:
+
+```shell script
+docker build -t test . && docker run -it test
+```

--- a/ext/tests/002.phpt
+++ b/ext/tests/002.phpt
@@ -14,7 +14,7 @@ Warning: PHPGo\Module\test_%s::boolAnd() expects exactly 2 parameters, 1 given i
 
 Warning: PHPGo\Module\test_%s::boolAnd() expects exactly 2 parameters, 3 given in %s on line %d
 
-Warning: PHPGo\Module\test_%s::boolAnd() expects parameter 1 to be bool, object given in %s on line %d
+Warning: PHPGo\Module\test_%s::boolAnd() expects parameter 1 to be %r(bool|boolean)%r, object given in %s on line %d
 
 Warning: Failed loading %s/nop.so (test): %s in %s on line %d
 

--- a/ext/tests/002.phpt
+++ b/ext/tests/002.phpt
@@ -14,7 +14,7 @@ Warning: PHPGo\Module\test_%s::boolAnd() expects exactly 2 parameters, 1 given i
 
 Warning: PHPGo\Module\test_%s::boolAnd() expects exactly 2 parameters, 3 given in %s on line %d
 
-Warning: PHPGo\Module\test_%s::boolAnd() expects parameter 1 to be boolean, object given in %s on line %d
+Warning: PHPGo\Module\test_%s::boolAnd() expects parameter 1 to be bool, object given in %s on line %d
 
 Warning: Failed loading %s/nop.so (test): %s in %s on line %d
 

--- a/ext/tests/003.phpt
+++ b/ext/tests/003.phpt
@@ -3,7 +3,7 @@ Reflection
 --FILE--
 <?php
 $module = phpgo_load(__DIR__ . "/fixtures/go/test.so", "test");
-ReflectionClass::export($module);
+echo new ReflectionClass($module), "\n";
 --EXPECTF--
 Class [ <internal:phpgo> final class PHPGo\Module\test_%s ] {
 

--- a/local-test.sh
+++ b/local-test.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+NO_INTERACTION=1 make test 2>&1
+if test $? -gt 0
+then
+  for f in /gopath/src/github.com/arnaud-lb/php-go/ext/tests/*.diff
+    do
+      printf "\n\n"
+      printf "=====================================================================\n"
+      printf "Errors in $f\n"
+      printf "=====================================================================\n\n"
+      printf "$(cat $f)\n"
+    done
+fi
+


### PR DESCRIPTION
Rapid testing can be troublesome relying on Travis only (as well as the fact that they've now deprecated "travis compile").

This is a Dockerfile which creates a clean environment and runs the PHP Tests on a local machine based on the currently checked out branch.

Additionally there was a deprecated call in the Reflection tests and a type mismatch in the Error Conditions test.